### PR TITLE
Django 1.10 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,15 @@ env:
   matrix:
     - TOX_ENV=py27-dj18
     - TOX_ENV=py27-dj19
+    - TOX_ENV=py27-dj110
     - TOX_ENV=py27-djdev
     - TOX_ENV=py34-dj18
     - TOX_ENV=py34-dj19
+    - TOX_ENV=py34-dj110
     - TOX_ENV=py34-djdev
     - TOX_ENV=py35-dj18
     - TOX_ENV=py35-dj19
+    - TOX_ENV=py35-dj110
     - TOX_ENV=py35-djdev
 matrix:
   fast_finish: true

--- a/django_sharding_library/decorators.py
+++ b/django_sharding_library/decorators.py
@@ -46,13 +46,8 @@ def model_config(shard_group=None, database=None, sharded_by_field=None):
                 try:
                     if not isinstance(cls.objects, ShardManager):
                         if type(cls.objects) == Manager:
-                            to_add = ShardManager()
-                            to_add.name = 'shard_manager'
-                            cls.add_to_class('objects', to_add)
-                            if django.VERSION >= (1, 10):
-                                cls._meta.base_manager = cls.objects
-                                cls._meta.add_manager(to_add)
-                            else:
+                            cls.add_to_class('objects', ShardManager())
+                            if django.VERSION < (1, 10):
                                 cls._base_manager = cls.objects
                         else:
                             raise ShardedModelInitializationException('You must use the default Django model manager or'

--- a/django_sharding_library/decorators.py
+++ b/django_sharding_library/decorators.py
@@ -46,9 +46,12 @@ def model_config(shard_group=None, database=None, sharded_by_field=None):
                 try:
                     if not isinstance(cls.objects, ShardManager):
                         if type(cls.objects) == Manager:
-                            cls.add_to_class('objects', ShardManager())
+                            to_add = ShardManager()
+                            to_add.name = 'shard_manager'
+                            cls.add_to_class('objects', to_add)
                             if django.VERSION >= (1, 10):
                                 cls._meta.base_manager = cls.objects
+                                cls._meta.add_manager(to_add)
                             else:
                                 cls._base_manager = cls.objects
                         else:

--- a/django_sharding_library/decorators.py
+++ b/django_sharding_library/decorators.py
@@ -1,3 +1,4 @@
+import django
 from django.conf import settings
 
 from django_sharding_library.exceptions import NonExistentDatabaseException, ShardedModelInitializationException
@@ -46,7 +47,10 @@ def model_config(shard_group=None, database=None, sharded_by_field=None):
                     if not isinstance(cls.objects, ShardManager):
                         if type(cls.objects) == Manager:
                             cls.add_to_class('objects', ShardManager())
-                            cls._base_manager = cls.objects
+                            if django.VERSION >= (1, 10):
+                                cls._meta.base_manager = cls.objects
+                            else:
+                                cls._base_manager = cls.objects
                         else:
                             raise ShardedModelInitializationException('You must use the default Django model manager or'
                                                                       ' your custom manager must inherit from '

--- a/django_sharding_library/decorators.py
+++ b/django_sharding_library/decorators.py
@@ -55,10 +55,19 @@ def model_config(shard_group=None, database=None, sharded_by_field=None):
                                                                       '``ShardManager``')
                 except AttributeError as e:
                     if cls._meta.abstract:
-                        if not len(cls._meta.abstract_managers) > 0:
-                            cls.add_to_class('objects', ShardManager())
-                        elif not any([isinstance(x[2], ShardManager) for x in cls._meta.abstract_managers]):
-                            raise ShardedModelInitializationException('Please either do not specify a manager in your '
+                        if django.VERSION < (1, 10):
+                            if not len(cls._meta.abstract_managers) > 0:
+                                cls.add_to_class('objects', ShardManager())
+                            elif not any([isinstance(x[2], ShardManager) for x in cls._meta.abstract_managers]):
+                                raise ShardedModelInitializationException('Please either do not specify a manager in your '
+                                                                      'abstract base class %s, or if you are using a '
+                                                                      'custom manager, your custom manager must '
+                                                                      'inherit from ``ShardManager``' % cls.__name__)
+                        else:
+                            if all([isinstance(x, Manager) for x in cls._meta.managers]):
+                                cls.add_to_class('objects', ShardManager())
+                            elif not any([isinstance(x, ShardManager) for x in cls._meta.managers]):
+                                raise ShardedModelInitializationException('Please either do not specify a manager in your '
                                                                       'abstract base class %s, or if you are using a '
                                                                       'custom manager, your custom manager must '
                                                                       'inherit from ``ShardManager``' % cls.__name__)

--- a/django_sharding_library/decorators.py
+++ b/django_sharding_library/decorators.py
@@ -56,21 +56,17 @@ def model_config(shard_group=None, database=None, sharded_by_field=None):
                 except AttributeError as e:
                     if cls._meta.abstract:
                         if django.VERSION < (1, 10):
-                            if not len(cls._meta.abstract_managers) > 0:
-                                cls.add_to_class('objects', ShardManager())
-                            elif not any([isinstance(x[2], ShardManager) for x in cls._meta.abstract_managers]):
-                                raise ShardedModelInitializationException('Please either do not specify a manager in your '
-                                                                      'abstract base class %s, or if you are using a '
-                                                                      'custom manager, your custom manager must '
-                                                                      'inherit from ``ShardManager``' % cls.__name__)
+                            managers = [x[2] for x in cls._meta.abstract_managers]
                         else:
-                            if all([isinstance(x, Manager) for x in cls._meta.managers]):
-                                cls.add_to_class('objects', ShardManager())
-                            elif not any([isinstance(x, ShardManager) for x in cls._meta.managers]):
-                                raise ShardedModelInitializationException('Please either do not specify a manager in your '
-                                                                      'abstract base class %s, or if you are using a '
-                                                                      'custom manager, your custom manager must '
-                                                                      'inherit from ``ShardManager``' % cls.__name__)
+                            managers = cls._meta.managers
+
+                        if not len(managers) > 0:
+                            cls.add_to_class('objects', ShardManager())
+                        elif not any([isinstance(x, ShardManager) for x in managers]):
+                            raise ShardedModelInitializationException('Please either do not specify a manager in your '
+                                                                  'abstract base class %s, or if you are using a '
+                                                                  'custom manager, your custom manager must '
+                                                                  'inherit from ``ShardManager``' % cls.__name__)
                     else:
                         # If it gets to this point, the error is a Django error and not a library one. Pass it through.
                         raise e

--- a/django_sharding_library/manager.py
+++ b/django_sharding_library/manager.py
@@ -50,6 +50,11 @@ class ShardQuerySet(QuerySet):
 
 class ShardManager(Manager):
 
+    def __init__(self, *args, **kwargs):
+        return_value = super(ShardManager, self).__init__(*args, **kwargs)
+        self.name = 'shard_manager'
+        return return_value
+
     def get_query_set(self, key=None):
         # todo: (eventually, not necessary now) Should check to make sure the there is a good kwarg OR an instance ->
         # available here

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,4 +1,4 @@
-psycopg2==2.6.1
+psycopg2==2.6.2
 mysqlclient==1.3.7
-mock==1.0.1
-django_nose==1.4.2
+mock==2.0.0
+django_nose==1.4.4

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=['Django>=1.8', 'dj-database-url==0.3.0'],
-    tests_require=['psycopg2==2.6.1', 'mysqlclient==1.3.7', 'mock==1.0.1', 'django_nose==1.4.2', 'tox==2.1.1'],
+    tests_require=['psycopg2==2.6.2', 'mysqlclient==1.3.7', 'mock==2.0.0', 'django_nose==1.4.4', 'tox==2.1.1'],
     license="BSD",
     zip_safe=False,
     keywords='django shard sharding library',

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-  py27-dj{18,19,dev}
-  py34-dj{18,19,dev}
-  py35-dj{18,19,dev}
+  py27-dj{18,19,110,dev}
+  py34-dj{18,19,110,dev}
+  py35-dj{18,19,110,dev}
 
 [testenv]
 passenv=
@@ -22,6 +22,7 @@ deps =
   -r{toxinidir}/requirements/development.txt
   dj18: Django>=1.8,<1.9
   dj19: Django>=1.9,<1.10
+  dj110: Django>=1.10,<1.11
   djdev: https://github.com/django/django/archive/master.tar.gz
 commands=
   coverage run --source=django_sharding,django_sharding_library -a setup.py test


### PR DESCRIPTION
Ensure all the tests are working and all seems good for Django 1.10

screwing around trying to figure out  a hacky way to make it work didn't work but I got this far and almost closed the terminal without copying it down:
```
ipdb> cls._meta.add_manager
<bound method Options.add_manager of <Options for TestModel>>
ipdb> cls._meta.add_manager(ShardManager())
ipdb> cls._meta.managers_map
{u'objects': <django.db.models.manager.Manager object at 0x7f22070741d0>, None: <class 'django_sharding_library.manager.ShardManager'>}
ipdb> cls._meta.managers_map['objects'] = cls._meta.managers_map[None]
```

the changes to `add_to_class` seem to have broken this. The above code works in place but doesn't persist.