### PR TITLE
Fixed a bug with Django 1.10 not using the abstract managers property…

### DIFF
--- a/django_sharding_library/decorators.py
+++ b/django_sharding_library/decorators.py
@@ -56,21 +56,17 @@ def model_config(shard_group=None, database=None, sharded_by_field=None):
                 except AttributeError as e:
                     if cls._meta.abstract:
                         if django.VERSION < (1, 10):
-                            if not len(cls._meta.abstract_managers) > 0:
-                                cls.add_to_class('objects', ShardManager())
-                            elif not any([isinstance(x[2], ShardManager) for x in cls._meta.abstract_managers]):
-                                raise ShardedModelInitializationException('Please either do not specify a manager in your '
-                                                                      'abstract base class %s, or if you are using a '
-                                                                      'custom manager, your custom manager must '
-                                                                      'inherit from ``ShardManager``' % cls.__name__)
+                            managers = [x[2] for x in cls._meta.abstract_managers]
                         else:
-                            if all([isinstance(x, Manager) for x in cls._meta.managers]):
-                                cls.add_to_class('objects', ShardManager())
-                            elif not any([isinstance(x, ShardManager) for x in cls._meta.managers]):
-                                raise ShardedModelInitializationException('Please either do not specify a manager in your '
-                                                                      'abstract base class %s, or if you are using a '
-                                                                      'custom manager, your custom manager must '
-                                                                      'inherit from ``ShardManager``' % cls.__name__)
+                            managers = cls._meta.managers
+
+                        if not len(managers) > 0:
+                            cls.add_to_class('objects', ShardManager())
+                        elif not any([isinstance(x, ShardManager) for x in managers]):
+                            raise ShardedModelInitializationException('Please either do not specify a manager in your '
+                                                                  'abstract base class %s, or if you are using a '
+                                                                  'custom manager, your custom manager must '
+                                                                  'inherit from ``ShardManager``' % cls.__name__)
                     else:
                         # If it gets to this point, the error is a Django error and not a library one. Pass it through.
                         raise e


### PR DESCRIPTION
Pull this into your 1.10 branch to fix that test erroring out. Looks like django 1.10 changed how it stores abstract models' managers. It actually makes way more sense this way, I am not sure why they did it the old way at all -_-