### PR TITLE
Updated postgres id field sequence creation

### DIFF
--- a/django_sharding_library/utils.py
+++ b/django_sharding_library/utils.py
@@ -10,7 +10,7 @@ def create_postgres_global_sequence(sequence_name, db_alias, reset_sequence=Fals
     create_sequence_if_not_exists_sql = """DO
 $$
 BEGIN
-        CREATE SEQUENCE myseq;
+        CREATE SEQUENCE %s;
 EXCEPTION WHEN duplicate_table THEN
         -- do nothing, it's already there
 END


### PR DESCRIPTION
Currently, if the sequence already exists, the DB logs an error (no worries, it doesn't affect anything, its just annoying). This will use postgres' built in plpgsql embedded language to properly handle the exception without it bubbling up, effectively allowing for a create if not exists operation (which is not built into postgres)