### PR TITLE
Add ability to use environment variables with no database name in the url

### DIFF
--- a/django_sharding_library/settings_helpers.py
+++ b/django_sharding_library/settings_helpers.py
@@ -6,7 +6,7 @@ def database_config(environment_variable, default_database_url, database_name=No
     Wraps dj_database_url to provide additional arguments to specify whether a database is a shard
     and if it a replica of another database.
 
-    If the the environment_variable URL does not include the database name, it will use the database_name argument
+    If database_name is provided, it will override the database name in the environment_variable URL
     """
     db_config = config(env=environment_variable, default=default_database_url)
     if not db_config:
@@ -15,7 +15,7 @@ def database_config(environment_variable, default_database_url, database_name=No
     db_config['TEST'] = db_config.get('TEST', {})
     db_config['SHARD_GROUP'] = shard_group
 
-    if not db_config['NAME'] and database_name is not None:
+    if database_name is not None:
         db_config['NAME'] = database_name
 
     if is_replica_of:
@@ -27,8 +27,7 @@ def database_config(environment_variable, default_database_url, database_name=No
 
 def database_configs(databases_dict):
     """
-    Takes databases of the form (note the database_name is optional and meant to be used when the environment_variable
-    does not contain the database name):
+    Takes databases of the form (database_name is optional, and will override any database name set in the URL):
     {
         'unsharded_databases': [
             {

--- a/django_sharding_library/settings_helpers.py
+++ b/django_sharding_library/settings_helpers.py
@@ -1,10 +1,12 @@
 from dj_database_url import config
 
 
-def database_config(environment_variable, default_database_url, shard_group=None, is_replica_of=None):
+def database_config(environment_variable, default_database_url, database_name=None, shard_group=None, is_replica_of=None):
     """
     Wraps dj_database_url to provide additional arguments to specify whether a database is a shard
     and if it a replica of another database.
+
+    If the the environment_variable URL does not include the database name, it will use the database_name argument
     """
     db_config = config(env=environment_variable, default=default_database_url)
     if not db_config:
@@ -12,6 +14,9 @@ def database_config(environment_variable, default_database_url, shard_group=None
 
     db_config['TEST'] = db_config.get('TEST', {})
     db_config['SHARD_GROUP'] = shard_group
+
+    if not db_config['NAME'] and database_name is not None:
+        db_config['NAME'] = database_name
 
     if is_replica_of:
         db_config['PRIMARY'] = is_replica_of
@@ -22,25 +27,30 @@ def database_config(environment_variable, default_database_url, shard_group=None
 
 def database_configs(databases_dict):
     """
-    Takes databases of the form:
+    Takes databases of the form (note the database_name is optional and meant to be used when the environment_variable
+    does not contain the database name):
     {
         'unsharded_databases': [
             {
                 'name': 'DB01',
                 'environment_variable': 'ENV',
-                'default_database_url': 'postgres:://...'
+                'default_database_url': 'postgres:://...',
+                'database_name': 'db01'
             }, {
                 'name': 'DB02',
                'environment_variable': 'ENV2',
                 'default_database_url': 'postgres:://...',
+                'database_name': 'db02'
                 'replicas': [{
                     'name': 'DB02_S1',
                     'environment_variable': 'ENVS1',
-                    'default_database_url': 'postgres:://...'
+                    'default_database_url': 'postgres:://...',
+                    'database_name': 'db02'
                 }, {
                     'name': 'DB02_S2',
                     'environment_variable': 'ENVS2',
-                    'default_database_url': 'postgres:://...'
+                    'default_database_url': 'postgres:://...',
+                    'database_name': 'db02'
                 }]
             },],
         'sharded_databases': [
@@ -76,6 +86,7 @@ def database_configs(databases_dict):
             db_config = database_config(
                 database['environment_variable'],
                 database['default_database_url'],
+                database_name=database.get('database_name'),
                 shard_group=(is_sharded and database.get('shard_group', 'default')) or None,
                 is_replica_of=None
             )
@@ -85,6 +96,7 @@ def database_configs(databases_dict):
                 db_config = database_config(
                     replica['environment_variable'],
                     replica['default_database_url'],
+                    database_name=database.get('database_name'),
                     shard_group=(is_sharded and database.get('shard_group', 'default') or None),
                     is_replica_of=database['name']
                 )

--- a/tests/test_settings_helpers.py
+++ b/tests/test_settings_helpers.py
@@ -100,6 +100,45 @@ class DatabaseConfigsTestCase(TestCase):
 
         self.assertEqual(result, {'DB01': DB01})
 
+    def test_database_name_overrides_url(self):
+        simple_config = {
+            'unsharded_databases': [
+                {
+                    'name': 'DB01',
+                    'environment_variable': 'SOME_OTHER_USELESS_ENV',
+                    'default_database_url': self.default_database_url,
+                    'database_name': 'another_db'
+                }
+            ]
+        }
+        result = database_configs(simple_config)
+
+        DB01 = {'SHARD_GROUP': None, 'TEST': {}}
+        DB01.update(self.dj_database_config)
+        DB01['NAME'] = 'another_db'
+
+        self.assertEqual(result, {'DB01': DB01})
+
+    def test_database_name_missing_in_url(self):
+        simple_config = {
+            'unsharded_databases': [
+                {
+                    'name': 'DB01',
+                    'environment_variable': 'SOME_OTHER_USELESS_ENV',
+                    'default_database_url': self.default_database_url.rstrip('test_db'),
+                    'database_name': 'another_db'
+                }
+            ]
+        }
+        result = database_configs(simple_config)
+
+        DB01 = {'SHARD_GROUP': None, 'TEST': {}}
+        DB01.update(self.dj_database_config)
+        DB01['NAME'] = 'another_db'
+
+        self.assertEqual(result, {'DB01': DB01})
+
+
     def test_unsharded_databases_ignore_shard_group(self):
         simple_config = {
             'unsharded_databases': [


### PR DESCRIPTION
Allows for the use of database URL environment variables with no database name specified. This will in turn result in less environment variables needed to be set when there are many shards per database node.

For example imagine an app with 1 primary database and 8 shards distributed over 3 database servers:

```
DB_NODE_001_URL=postgres://user:passwd@node001.company.org:5432
DB_SHARD_NODE_001_URL=postgres://user:passwd@shardnode001.company.org:5432
DB_SHARD_NODE_002_URL=postgres://user:passwd@shardnode002.company.org:5432
```


```
    {
        'unsharded_databases': [
            {
                'name': 'DB01',
                'environment_variable': 'DB_NODE_001_URL',
                'default_database_url': 'postgres:://...',
                'database_name': 'db01'
            }
        ],
        'sharded_databases': [
            {
                'name': 'SHARD_01',
                'environment_variable': 'DB_SHARD_NODE_001_URL',
                'default_database_url': 'postgres:://...',
                'database_name': 'shard01',
                'shard_group': 'default',
            }, {
                'name': 'SHARD_02',
                'environment_variable': 'DB_SHARD_NODE_001_URL',
                'default_database_url': 'postgres:://...',
                'database_name': 'shard02',
                'shard_group': 'default',
            }, {
                'name': 'SHARD_03',
                'environment_variable': 'DB_SHARD_NODE_001_URL',
                'default_database_url': 'postgres:://...',
                'database_name': 'shard03',
                'shard_group': 'default',
            }, {
                'name': 'SHARD_04',
                'environment_variable': 'DB_SHARD_NODE_001_URL',
                'default_database_url': 'postgres:://...',
                'database_name': 'shard04',
                'shard_group': 'default',
            }, {
                'name': 'SHARD_05',
                'environment_variable': 'DB_SHARD_NODE_002_URL',
                'default_database_url': 'postgres:://...',
                'database_name': 'shard05,
                'shard_group': 'default',
            }, {
                'name': 'SHARD_06',
                'environment_variable': 'DB_SHARD_NODE_002_URL',
                'default_database_url': 'postgres:://...',
                'database_name': 'shard06',
                'shard_group': 'default',
            }, {
                'name': 'SHARD_07',
                'environment_variable': 'DB_SHARD_NODE_002_URL',
                'default_database_url': 'postgres:://...',
                'database_name': 'shard07',
                'shard_group': 'default',
            }, {
                'name': 'SHARD_08',
                'environment_variable': 'DB_SHARD_NODE_002_URL',
                'default_database_url': 'postgres:://...',
                'database_name': 'shard08',
                'shard_group': 'default',
            },
        ]
    }
```