### PR TITLE
Exclude tests from being packaged and installed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author='JBKahn',
     author_email='josephbkahn@gmail.com',
     url='https://github.com/JBKahn/django-sharding',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests']),
     include_package_data=True,
     install_requires=get_requirements('requirements/common.txt') + ["django>=1.8,<3.0.0"],
     tests_require=get_requirements('requirements/development.txt'),


### PR DESCRIPTION
With the current use of find_packages, the "tests" package is discovered and installed alongside the django_sharding and django_sharding_packages. This appears to be unintentional, and we probably don't want users to accidentally get this test package.

This change excludes it from being discovered during packaging.